### PR TITLE
fix: add required return statements to `coordinates` function

### DIFF
--- a/pycute/shape.py
+++ b/pycute/shape.py
@@ -271,10 +271,13 @@ def coordinates(shape: Shape):
   """
   if is_int(shape):
     yield from range(shape)
+    return
   if is_tuple(shape):
     if len(shape) == 0:
       yield ()
+      return
     for rest in coordinates(shape[1:]):
       for c in coordinates(shape[0]):
         yield (c,) + rest
+    return
   raise TypeError(f"coordinates({shape})")

--- a/test/test_htuple.py
+++ b/test/test_htuple.py
@@ -81,6 +81,12 @@ class TestHTuple:
       assert idx != idx2crd(idx,shape)
       assert idx == crd2idx(idx2crd(idx,shape),shape)
 
+  def test_coordinates(self) -> None:
+    assert list(coordinates(6)) == [0, 1, 2, 3, 4, 5]
+    assert list(coordinates((3, 2))) == [(0,0), (1,0), (2,0), (0,1), (1,1), (2,1)]
+    assert list(coordinates((2, (2, 2)))) == [(0,(0,0)), (1,(0,0)), (0,(1,0)), (1,(1,0)),
+                                       (0,(0,1)), (1,(0,1)), (0,(1,1)), (1,(1,1))]
+
   def test_slice_dice(self):
     shape = ((2, 3), (5, 7, 9))
 


### PR DESCRIPTION
the `coordinates` function in `shape.py` is bugged due to execution proceeding after iterators are exhausted. This is revealed by a new test that runs the examples from the docstring of `coordinates`. The fix is to sprinkle return statements after branches where iterators should be exhausted. 